### PR TITLE
Include stdlib.h instead of malloc.h

### DIFF
--- a/include/external_calls.h
+++ b/include/external_calls.h
@@ -26,7 +26,7 @@
 #define __external_calls_h__
 
 #include <memory.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #define	mem_alloc(size)				malloc(size)
 #define	mem_free(addr)				free(addr)


### PR DESCRIPTION
Had to make this change in order to build on macOS ☺️ 

The `<malloc.h>` header is deprecated and doesn't work on macOS. This patch replaces its usage with `<stdlib.h>` which is defined in the C89 standard.