### PR TITLE
Correct format string for 64-bit build

### DIFF
--- a/test/curve25519_selftest.c
+++ b/test/curve25519_selftest.c
@@ -390,8 +390,13 @@ void edp_DualPointMultiply(
 void print_words(IN const char *txt, IN const U_WORD *data, IN U32 size)
 {
     U32 i;
-    printf("%s0x%08X", txt, (unsigned int)(*data++));
-    for (i = 1; i < size; i++) printf(",0x%08X", (unsigned int)(*data++));
+#ifdef USE_ASM_LIB
+    printf("%s0x%08llX", txt, *data++);
+    for (i = 1; i < size; i++) printf(",0x%08llX", *data++);
+#else
+    printf("%s0x%08X", txt, *data++);
+    for (i = 1; i < size; i++) printf(",0x%08X", *data++);
+#endif
 }
 
 void pre_compute_base_point()

--- a/test/curve25519_selftest.c
+++ b/test/curve25519_selftest.c
@@ -392,7 +392,7 @@ void print_words(IN const char *txt, IN const U_WORD *data, IN U32 size)
     U32 i;
 #ifdef WORDSIZE_64
     printf("%s0x%016llX", txt, *data++);
-    for (i = 1; i < size; i++) printf(",0x%08llX", *data++);
+    for (i = 1; i < size; i++) printf(",0x%016llX", *data++);
 #else
     printf("%s0x%08X", txt, *data++);
     for (i = 1; i < size; i++) printf(",0x%08X", *data++);

--- a/test/curve25519_selftest.c
+++ b/test/curve25519_selftest.c
@@ -390,8 +390,8 @@ void edp_DualPointMultiply(
 void print_words(IN const char *txt, IN const U_WORD *data, IN U32 size)
 {
     U32 i;
-#ifdef USE_ASM_LIB
-    printf("%s0x%08llX", txt, *data++);
+#ifdef WORDSIZE_64
+    printf("%s0x%016llX", txt, *data++);
     for (i = 1; i < size; i++) printf(",0x%08llX", *data++);
 #else
     printf("%s0x%08X", txt, *data++);

--- a/test/curve25519_selftest.c
+++ b/test/curve25519_selftest.c
@@ -390,8 +390,8 @@ void edp_DualPointMultiply(
 void print_words(IN const char *txt, IN const U_WORD *data, IN U32 size)
 {
     U32 i;
-    printf("%s0x%08X", txt, *data++);
-    for (i = 1; i < size; i++) printf(",0x%08X", *data++);
+    printf("%s0x%08X", txt, (unsigned int)(*data++));
+    for (i = 1; i < size; i++) printf(",0x%08X", (unsigned int)(*data++));
 }
 
 void pre_compute_base_point()


### PR DESCRIPTION
This corrects the following warnings in the 64-bit debug build:
error C2220: the following warning is treated as an error
test\curve25519_selftest.c(393,12): warning C4477: 'printf' : format string '%08X' requires an argument of type 'unsigned int', but variadic argument 2 has type 'const U64'