### PR TITLE
Fixed typo

### DIFF
--- a/C++/ed25519.cpp
+++ b/C++/ed25519.cpp
@@ -57,7 +57,7 @@ const unsigned char* ED25519Public::GetKeyBytes(
     return &m_Key[0];
 }
 
-bool ED25519Public::VeifySignature(
+bool ED25519Public::VerifySignature(
     const unsigned char* msg,           /* IN: [msg_size bytes] message to sign */
     unsigned int msg_size,              /* IN: size of message */
     const unsigned char* signature)     /* IN: [64 bytes] signature (R,S) */

--- a/C++/ed25519.h
+++ b/C++/ed25519.h
@@ -34,7 +34,7 @@ public:
 
     const unsigned char* GetKeyBytes(unsigned char* publicKey) const;
 
-    bool VeifySignature(
+    bool VerifySignature(
         const unsigned char* msg,           /* IN: [msg_size bytes] message to sign */
         unsigned int msg_size,              /* IN: size of message */
         const unsigned char* signature);    /* IN: [64 bytes] signature (R,S) */


### PR DESCRIPTION
from `VeifySignature` to `VerifySignature` if I understand the common method naming rule correctly.